### PR TITLE
Support `gio` as trash implementation

### DIFF
--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -126,6 +126,10 @@ bool MoveItemToTrash(const base::FilePath& full_path) {
   } else if (trash.compare("trash-cli") == 0) {
     argv.push_back("trash-put");
     argv.push_back(full_path.value());
+  } else if (trash.compare("gio") == 0) {
+    argv.push_back("gio");
+    argv.push_back("trash");
+    argv.push_back(full_path.value());
   } else {
     argv.push_back(ELECTRON_DEFAULT_TRASH);
     argv.push_back(full_path.value());


### PR DESCRIPTION
Ideally this will become the default as `gvfs-trash` is deprecated and nothing more than a wrapper to `gio` but at least allow easily opting into the modern method.